### PR TITLE
add: GitHub templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report / バグ報告
+about: Create a report to help us improve / 改善のためのバグ報告
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+
+---
+
+## Bug Description / バグの概要
+<!-- A clear and concise description of what the bug is / バグの内容を簡潔に説明してください -->
+
+## Steps to Reproduce / 再現手順
+<!-- Steps to reproduce the behavior / バグを再現するための手順を記載してください -->
+1. 
+2. 
+3. 
+
+## Expected Behavior / 期待される動作
+<!-- A clear and concise description of what you expected to happen / 正常に動作した場合の期待される結果を記載してください -->
+
+## Actual Behavior / 実際の動作
+<!-- A clear and concise description of what actually happened / 実際に発生した動作を記載してください -->
+
+## Environment / 環境
+- OS: 
+- Node.js version / Node.js バージョン: 
+- tsenv version / tsenv バージョン: 
+- Other relevant environment information / その他関連する環境情報: 
+
+## Error Logs (if any) / エラーログ（あれば）
+```
+Paste error logs here / エラーログをここに貼り付けてください
+```
+
+## Screenshots (if applicable) / スクリーンショット（必要に応じて）
+<!-- Add screenshots to help explain your problem / 問題を説明するのに役立つスクリーンショットがあれば添付してください -->
+
+## Additional Context / その他
+<!-- Add any other context about the problem here / その他、バグの解決に役立つ情報があれば記載してください -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request / 機能リクエスト
+about: Suggest an idea for this project / このプロジェクトへの新機能の提案
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Feature Description / 機能の説明
+<!-- A clear and concise description of the feature you'd like / 実装してほしい機能の明確で簡潔な説明 -->
+
+## Problem to Solve / 解決したい問題
+<!-- Describe the problem this feature would solve / この機能が解決する問題を説明してください -->
+
+## Proposed Solution / 提案する解決策
+<!-- Describe your proposed solution / 提案する解決策を説明してください -->
+
+## Alternative Solutions / 代替案
+<!-- Describe any alternative solutions or features you've considered / 検討した代替案や機能があれば説明してください -->
+
+## Use Case / ユースケース
+<!-- Provide specific use cases for this feature / この機能の具体的なユースケースを提供してください -->
+
+## Additional Context / その他
+<!-- Add any other context, screenshots, or examples about the feature request here / 機能リクエストに関するその他のコンテキスト、スクリーンショット、または例を追加してください -->

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,29 @@
+---
+name: General Issue / 一般的な課題
+about: For issues that don't fit other categories / 他のカテゴリに当てはまらない課題
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Issue Type / 課題の種類
+<!-- Select the type that best describes this issue / この課題を最もよく表すタイプを選択してください -->
+- [ ] Question / 質問
+- [ ] Documentation / ドキュメント
+- [ ] Refactoring / リファクタリング
+- [ ] Performance / パフォーマンス
+- [ ] Security / セキュリティ
+- [ ] Other / その他
+
+## Description / 説明
+<!-- Provide a clear and detailed description of the issue / 課題の明確で詳細な説明を提供してください -->
+
+## Context / 背景
+<!-- Provide any relevant context or background information / 関連する背景情報を提供してください -->
+
+## Expected Outcome / 期待される結果
+<!-- Describe what you would like to see happen / 期待する結果を説明してください -->
+
+## Additional Information / 追加情報
+<!-- Add any other relevant information, links, or references / その他の関連情報、リンク、または参考資料を追加してください -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary / 概要
+<!-- Briefly describe what this PR achieves / このPRで何を実現するか簡潔に記述してください -->
+
+## Changes / 変更内容
+<!-- List the changes made in this PR / 実装した内容を箇条書きで記述してください -->
+- 
+
+## Related Issue / 関連するIssue
+<!-- Link any related issues / 関連するIssueがある場合は記載してください -->
+Closes #
+
+## Checklist / 確認項目
+- [ ] Tests pass successfully / テストを実行し、すべて成功することを確認した
+- [ ] Type checking passes / 型チェックが通ることを確認した
+- [ ] Documentation updated if necessary / ドキュメントの更新が必要な場合は更新した
+- [ ] Breaking changes documented if any / 破壊的変更がある場合は明記した
+
+## Screenshots (if applicable) / スクリーンショット（必要に応じて）
+<!-- Include screenshots for UI changes / UIの変更がある場合はスクリーンショットを添付してください -->
+
+## Additional Notes / その他
+<!-- Any additional information for reviewers / レビュアーに伝えたいことがあれば記載してください -->


### PR DESCRIPTION
## Summary

Add comprehensive GitHub templates to improve issue and pull request management.

## Changes

- Added bilingual (English/Japanese) pull request template with checklist and standardized sections
- Added bug report template with reproduction steps and environment details
- Added feature request template with problem description and use case sections
- Added general issue template for questions and other categories

## Test plan

- [x] Templates are properly formatted with YAML frontmatter
- [x] All templates include bilingual content (English/Japanese)
- [x] Templates follow GitHub's issue template conventions

🤖 Generated with [Claude Code](https://claude.ai/code)