### PR TITLE
feat: enable manual triggering of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger to allow manual execution of the release workflow from GitHub Actions UI

## Test plan
- [ ] Verify the release workflow can be manually triggered from GitHub Actions page
- [ ] Confirm the workflow still triggers automatically on push to main branch

🤖 Generated with [Claude Code](https://claude.ai/code)