### PR TITLE
fix: resolve semantic-release CI failure with noVerify option

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,8 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "pnpm-lock.yaml", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        "noVerify": true
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
- Add `noVerify: true` option to `@semantic-release/git` configuration to skip git hooks during release commits
- This fixes the CI release workflow failure where lefthook pre-commit hooks were causing biome format checks to fail

## Problem
The semantic-release workflow was failing because:
1. semantic-release updates package.json and creates a release commit
2. This triggers lefthook's pre-commit hooks
3. Biome format checks fail on the updated package.json
4. The git commit fails, causing the entire release process to fail

## Solution
Adding `noVerify: true` to the semantic-release git configuration ensures that:
- Release commits bypass git hooks (preventing the format check failure)
- Regular development commits still run all pre-commit checks
- The release process can complete successfully

## Test plan
- [x] Updated semantic-release configuration with noVerify option
- [ ] Verify the release workflow completes successfully on merge

🤖 Generated with [Claude Code](https://claude.ai/code)