### PR TITLE
fix: disable lefthook during semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          LEFTHOOK: 0
         run: pnpm semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,8 +9,7 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "pnpm-lock.yaml", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-        "noVerify": true
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,8 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "pnpm-lock.yaml", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+        "noVerify": true
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
- Add `LEFTHOOK=0` environment variable to disable git hooks during semantic-release workflow
- Remove the `noVerify` option from semantic-release config as it wasn't effective

## Problem
The previous fix using `noVerify: true` didn't work because:
- The @semantic-release/git version being used doesn't support the noVerify option
- Lefthook hooks were still being triggered during the semantic-release commit process
- This caused biome format checks to fail on the auto-updated package.json

## Solution
Using `LEFTHOOK=0` environment variable in the GitHub Actions workflow:
- Completely disables lefthook during the semantic-release process
- Ensures no git hooks run during release commits
- Preserves hooks for regular development commits

## Test plan
- [x] Updated GitHub Actions workflow with LEFTHOOK=0 environment variable
- [x] Removed ineffective noVerify option from semantic-release config
- [ ] Verify the release workflow completes successfully on merge

🤖 Generated with [Claude Code](https://claude.ai/code)