### PR TITLE
fix: add publishConfig for public npm access

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "url": "https://github.com/kobapi28/tsenv/issues"
   },
   "homepage": "https://github.com/kobapi28/tsenv#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@10.11.1",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary
• Configure scoped package to publish as public to resolve npm 402 payment error
• Add publishConfig.access: "public" to package.json for @kobapi28/tsenv package

## Test plan
- [ ] Verify package.json contains publishConfig section
- [ ] Test npm publish command works without 402 error
- [ ] Confirm package is published as public on npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)