### PR TITLE
chore: add Claude Code settings for pnpm command permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(cd:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(pnpm add:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm build:*)",
+      "Bash(pnpm biome:*)",
+      "Bash(pnpm type:check:*)",
+      "Bash(pnpm check:*)",
+      "Bash(pnpm dev:*)",
+      "Bash(pnpm test:*)",
+      "Bash(git add:*)",
+      "Bash(git status:*)",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git checkout:*)",
+      "Bash(git branch:*)",
+      "Bash(git rebase:*)",
+      "Bash(git diff:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr view:*)"
+    ],
+    "deny": []
+  }
+}


### PR DESCRIPTION
## Summary
- Added `.claude/settings.json` to configure Claude Code permissions for pnpm commands
- Allows execution of common pnpm commands and git operations without manual approval

## Test plan
- [x] Verify Claude Code can run pnpm commands after this configuration
- [x] Confirm settings file follows Claude Code configuration format

🤖 Generated with [Claude Code](https://claude.ai/code)