### PR TITLE
feat: configure Mend Renovate with custom settings

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,0 +1,53 @@
+module.exports = {
+  extends: [
+    'config:base',
+    'schedule:weekends',
+    ':semanticCommitTypeAll(chore)'
+  ],
+  timezone: 'Asia/Tokyo',
+  labels: ['dependencies'],
+  packageRules: [
+    {
+      matchUpdateTypes: ['major'],
+      labels: ['dependencies', 'major']
+    },
+    {
+      matchUpdateTypes: ['minor'],
+      labels: ['dependencies', 'minor']
+    },
+    {
+      matchUpdateTypes: ['patch'],
+      labels: ['dependencies', 'patch']
+    },
+    {
+      matchDepTypes: ['devDependencies'],
+      labels: ['dependencies', 'devDependencies']
+    },
+    {
+      matchManagers: ['npm'],
+      rangeStrategy: 'bump'
+    }
+  ],
+  prConcurrentLimit: 10,
+  prHourlyLimit: 2,
+  automerge: false,
+  automergeType: 'pr',
+  automergeStrategy: 'squash',
+  platformAutomerge: false,
+  semanticCommits: 'enabled',
+  semanticCommitType: 'chore',
+  semanticCommitScope: 'deps',
+  commitMessagePrefix: 'chore(deps):',
+  commitMessageTopic: '{{depName}}',
+  commitMessageExtra: 'to {{newVersion}}',
+  vulnerabilityAlerts: {
+    labels: ['security'],
+    automerge: false
+  },
+  postUpdateOptions: [
+    'npmDedupe'
+  ],
+  npm: {
+    minimumReleaseAge: '3 days'
+  }
+};

--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -1,53 +1,51 @@
 module.exports = {
   extends: [
-    'config:base',
-    'schedule:weekends',
-    ':semanticCommitTypeAll(chore)'
+    "config:base",
+    "schedule:weekends",
+    ":semanticCommitTypeAll(chore)",
   ],
-  timezone: 'Asia/Tokyo',
-  labels: ['dependencies'],
+  timezone: "Asia/Tokyo",
+  labels: ["dependencies"],
   packageRules: [
     {
-      matchUpdateTypes: ['major'],
-      labels: ['dependencies', 'major']
+      matchUpdateTypes: ["major"],
+      labels: ["dependencies", "major"],
     },
     {
-      matchUpdateTypes: ['minor'],
-      labels: ['dependencies', 'minor']
+      matchUpdateTypes: ["minor"],
+      labels: ["dependencies", "minor"],
     },
     {
-      matchUpdateTypes: ['patch'],
-      labels: ['dependencies', 'patch']
+      matchUpdateTypes: ["patch"],
+      labels: ["dependencies", "patch"],
     },
     {
-      matchDepTypes: ['devDependencies'],
-      labels: ['dependencies', 'devDependencies']
+      matchDepTypes: ["devDependencies"],
+      labels: ["dependencies", "devDependencies"],
     },
     {
-      matchManagers: ['npm'],
-      rangeStrategy: 'bump'
-    }
+      matchManagers: ["npm"],
+      rangeStrategy: "bump",
+    },
   ],
   prConcurrentLimit: 10,
   prHourlyLimit: 2,
   automerge: false,
-  automergeType: 'pr',
-  automergeStrategy: 'squash',
+  automergeType: "pr",
+  automergeStrategy: "squash",
   platformAutomerge: false,
-  semanticCommits: 'enabled',
-  semanticCommitType: 'chore',
-  semanticCommitScope: 'deps',
-  commitMessagePrefix: 'chore(deps):',
-  commitMessageTopic: '{{depName}}',
-  commitMessageExtra: 'to {{newVersion}}',
+  semanticCommits: "enabled",
+  semanticCommitType: "chore",
+  semanticCommitScope: "deps",
+  commitMessagePrefix: "chore(deps):",
+  commitMessageTopic: "{{depName}}",
+  commitMessageExtra: "to {{newVersion}}",
   vulnerabilityAlerts: {
-    labels: ['security'],
-    automerge: false
+    labels: ["security"],
+    automerge: false,
   },
-  postUpdateOptions: [
-    'npmDedupe'
-  ],
+  postUpdateOptions: ["npmDedupe"],
   npm: {
-    minimumReleaseAge: '3 days'
-  }
+    minimumReleaseAge: "3 days",
+  },
 };

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>kobapi28/tsenv//.github/renovate-config.js"
-  ]
+  "extends": ["github>kobapi28/tsenv//.github/renovate-config.js"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": [
+    "github>kobapi28/tsenv//.github/renovate-config.js"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add custom Renovate configuration to manage dependencies
- Configure weekend scheduling and timezone settings
- Set up automatic labeling and semantic commits

## Changes
- Created `.github/renovate-config.js` with custom Renovate settings
- Updated `renovate.json` to use the custom configuration
- Configured dependency update labels by type (major/minor/patch)
- Set up vulnerability alerts with security label
- Added npm dedupe post-update optimization

## Test plan
- [ ] Mend Renovate app will create an onboarding PR after merge
- [ ] Verify weekend scheduling works as expected
- [ ] Check that dependency PRs have appropriate labels
- [ ] Confirm semantic commit messages are properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)