### PR TITLE
feat: throw error when Env type is not found in schema file

### DIFF
--- a/src/parsers/schema-parser.ts
+++ b/src/parsers/schema-parser.ts
@@ -22,10 +22,12 @@ export function parseSchemaFile(schemaPath: string): Schema {
   );
 
   const schema: Schema = { fields: [] };
+  let foundEnvType = false;
 
   function visit(node: ts.Node) {
     // Handle type Env = { ... }
     if (ts.isTypeAliasDeclaration(node) && node.name.text === "Env") {
+      foundEnvType = true;
       if (ts.isTypeLiteralNode(node.type)) {
         extractFieldsFromTypeLiteral(node.type);
       }
@@ -55,6 +57,11 @@ export function parseSchemaFile(schemaPath: string): Schema {
   }
 
   visit(sourceFile);
+
+  if (!foundEnvType) {
+    throw new Error(`No 'Env' type declaration found in ${schemaPath}`);
+  }
+
   return schema;
 }
 

--- a/tests/schema-parser.test.ts
+++ b/tests/schema-parser.test.ts
@@ -151,8 +151,7 @@ type Env = {
       });
     });
 
-    // TODO: if can't find Env type, should throw an error
-    it("should return empty schema for files without Env type", () => {
+    it("should throw error for files without Env type", () => {
       const schemaPath = path.join(testSchemaDir, "empty.d.ts");
       const schemaContent = `
 type OtherType = {
@@ -165,9 +164,18 @@ interface SomeInterface {
 `;
       fs.writeFileSync(schemaPath, schemaContent);
 
-      const schema = parseSchemaFile(schemaPath);
+      expect(() => parseSchemaFile(schemaPath)).toThrow(
+        "No 'Env' type declaration found in",
+      );
+    });
 
-      expect(schema.fields).toHaveLength(0);
+    it("should throw error for completely empty files", () => {
+      const schemaPath = path.join(testSchemaDir, "completely-empty.d.ts");
+      fs.writeFileSync(schemaPath, "");
+
+      expect(() => parseSchemaFile(schemaPath)).toThrow(
+        "No 'Env' type declaration found in",
+      );
     });
 
     it("should handle complex nested structure (but only parse top-level Env)", () => {


### PR DESCRIPTION
## Summary
- Updated `parseSchemaFile` to throw error instead of returning empty schema when `Env` type is missing
- Modified test to expect error for files without `Env` type declaration  
- Added test case for completely empty schema files
- Addresses TODO comment in `schema-parser.test.ts:154`

## Test plan
- [x] Updated existing test to verify error is thrown when no `Env` type exists
- [x] Added new test for completely empty files
- [x] All existing tests still pass
- [x] Type checking and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)