### PR TITLE
fix: correct Renovate preset path in configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>kobapi28/tsenv//.github/renovate-config.js"]
+  "extends": ["github>kobapi28/tsenv/.github/renovate-config.js"]
 }


### PR DESCRIPTION
## Summary
- Fix double slash in GitHub preset path for Renovate configuration
- Change from `github>kobapi28/tsenv//.github/renovate-config.js` to `github>kobapi28/tsenv/.github/renovate-config.js`

## Test plan
- [x] Verify the `.github/renovate-config.js` file exists in the repository
- [x] Confirm the path syntax follows Renovate's GitHub preset format
- [ ] Monitor Renovate bot to ensure it can now process the configuration without errors

Fixes #29

🤖 Generated with [Claude Code](https://claude.ai/code)