### PR TITLE
feat: implement multiline support for environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,11 @@ If you receive an instruction from the user that is deemed to require consistent
 3. Thereafter, always apply it as a standard rule.
 
 Through this process, we will continuously improve the project's rules.
+
+# Package Manager
+This project uses **pnpm** as the package manager. Always use pnpm commands:
+- `pnpm install` - Install dependencies
+- `pnpm test` - Run tests
+- `pnpm build` - Build the project
+- `pnpm lint` - Run linting
+- `pnpm format` - Format code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,5 +14,7 @@ This project uses **pnpm** as the package manager. Always use pnpm commands:
 - `pnpm install` - Install dependencies
 - `pnpm test` - Run tests
 - `pnpm build` - Build the project
-- `pnpm lint` - Run linting
-- `pnpm format` - Format code
+- `pnpm biome:lint` - Run linting
+- `pnpm biome:format` - Format code
+- `pnpm type:check` - Type checking
+- `pnpm check` - Run type check and biome check

--- a/src/parsers/env-parser.ts
+++ b/src/parsers/env-parser.ts
@@ -17,23 +17,67 @@ export function parseEnvFile(filePath: string): EnvVariable[] {
   const parsed = parse(content);
   const variables: EnvVariable[] = [];
 
+  let currentKey: string | null = null;
+  let startLine = 0;
+  let inMultiline = false;
+
   lines.forEach((line, index) => {
     const trimmed = line.trim();
-    if (trimmed && !trimmed.startsWith("#")) {
-      const match = line.match(/^([^=]+)=(.*)$/);
-      if (match) {
-        const key = match[1].trim();
-        if (parsed[key] !== undefined) {
-          variables.push({
-            key,
-            value: parsed[key],
-            line: index + 1,
-            file: absolutePath,
-          });
-        }
+
+    // Skip empty lines and comments when not in multiline
+    if (!inMultiline && (!trimmed || trimmed.startsWith("#"))) {
+      return;
+    }
+
+    // Check if this line starts a new variable assignment
+    const match = line.match(/^([^=]+)=(.*)$/);
+    if (match && !inMultiline) {
+      const key = match[1].trim();
+      const value = match[2];
+
+      // Check if this starts a multiline value (quoted and not closed)
+      if (
+        (value.startsWith('"') && !value.endsWith('"')) ||
+        (value.startsWith("'") && !value.endsWith("'"))
+      ) {
+        currentKey = key;
+        startLine = index + 1;
+        inMultiline = true;
+      } else if (parsed[key] !== undefined) {
+        // Single line variable
+        variables.push({
+          key,
+          value: parsed[key],
+          line: index + 1,
+          file: absolutePath,
+        });
+      }
+    } else if (inMultiline && currentKey) {
+      // Check if this line ends the multiline value
+      const currentValue = parsed[currentKey];
+      if (currentValue !== undefined) {
+        // The multiline value is complete, add it
+        variables.push({
+          key: currentKey,
+          value: currentValue,
+          line: startLine,
+          file: absolutePath,
+        });
+        currentKey = null;
+        inMultiline = false;
       }
     }
   });
+
+  // Handle case where multiline value extends to end of file
+  if (inMultiline && currentKey && parsed[currentKey] !== undefined) {
+    variables.push({
+      key: currentKey,
+      value: parsed[currentKey],
+      line: startLine,
+      file: absolutePath,
+    });
+  }
 
   return variables;
 }

--- a/tests/env-parser.test.ts
+++ b/tests/env-parser.test.ts
@@ -128,31 +128,31 @@ JSON_CONFIG={"key":"value","number":123}
       });
     });
 
-    // TODO: multiline support
-    //     it("should handle multiline values", () => {
-    //       const envPath = path.join(testEnvDir, ".env");
-    //       const envContent = `PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
-    // MIIEpAIBAAKCAQEA0
-    // -----END RSA PRIVATE KEY-----"
-    // API_KEY=simple_value`;
-    //       fs.writeFileSync(envPath, envContent);
+    it("should handle multiline values", () => {
+      const envPath = path.join(testEnvDir, ".env");
+      const envContent = `PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0
+-----END RSA PRIVATE KEY-----"
+API_KEY=simple_value`;
+      fs.writeFileSync(envPath, envContent);
 
-    //       const variables = parseEnvFile(envPath);
+      const variables = parseEnvFile(envPath);
 
-    //       expect(variables).toHaveLength(2);
-    //       expect(variables).toContainEqual({
-    //         key: "PRIVATE_KEY",
-    //         value: "-----BEGIN RSA PRIVATE KEY-----MIIEpAIBAAKCAQEA0-----END RSA PRIVATE KEY-----",
-    //         line: 1,
-    //         file: path.resolve(envPath),
-    //       });
-    //       expect(variables).toContainEqual({
-    //         key: "API_KEY",
-    //         value: "simple_value",
-    //         line: 2,
-    //         file: path.resolve(envPath),
-    //       });
-    //     });
+      expect(variables).toHaveLength(2);
+      expect(variables).toContainEqual({
+        key: "PRIVATE_KEY",
+        value:
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0\n-----END RSA PRIVATE KEY-----",
+        line: 1,
+        file: path.resolve(envPath),
+      });
+      expect(variables).toContainEqual({
+        key: "API_KEY",
+        value: "simple_value",
+        line: 4,
+        file: path.resolve(envPath),
+      });
+    });
 
     it("should handle files with different line endings", () => {
       const envPath = path.join(testEnvDir, ".env");


### PR DESCRIPTION
## Summary
- Updated env-parser to properly handle quoted multiline values in .env files
- Enabled and fixed the multiline test case that was previously commented out as TODO
- Added pnpm usage guidelines to CLAUDE.md for consistent package management

## Test plan
- [x] All existing tests pass
- [x] New multiline test case passes
- [x] Code formatting and type checking pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)