### PR TITLE
fix: inline Renovate configuration to resolve preset loading error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,53 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>kobapi28/tsenv/.github/renovate-config.js"]
+  "extends": [
+    "config:recommended",
+    "schedule:weekends",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "major"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "labels": ["dependencies", "minor"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "labels": ["dependencies", "patch"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "labels": ["dependencies", "devDependencies"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "rangeStrategy": "bump"
+    }
+  ],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "automerge": false,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}",
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": false
+  },
+  "postUpdateOptions": ["npmDedupe"],
+  "npm": {
+    "minimumReleaseAge": "3 days"
+  }
 }


### PR DESCRIPTION
## Summary
- Replaced external GitHub preset reference with inline configuration
- Fixed "Cannot find preset's package" error that was preventing Renovate from running
- Closes #32

## Test plan
- [ ] Verify Renovate can now run without errors
- [ ] Check that dependency update PRs are created as expected

🤖 Generated with [Claude Code](https://claude.ai/code)