### PR TITLE
feat: throw error when no files match specified patterns

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -22,7 +22,9 @@ export async function checkCommand(options: CheckOptions) {
     }
 
     if (envFiles.length === 0) {
-      return;
+      throw new Error(
+        `No files match the specified patterns: ${config.files.join(", ")}`,
+      );
     }
 
     // Parse all env files

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -233,29 +233,28 @@ type Env = {
       expect(mockExit).not.toHaveBeenCalled();
     });
 
-    // TODO: throw error when no files match pattern
-    //     it("should handle missing env files when no files match pattern", async () => {
-    //       const configPath = path.join(testDir, "tsenv.config.js");
-    //       const schemaPath = path.join(testDir, "env.d.ts");
+    it("should throw error when no files match pattern", async () => {
+      const configPath = path.join(testDir, "tsenv.config.js");
+      const schemaPath = path.join(testDir, "env.d.ts");
 
-    //       const configContent = `
-    // module.exports = {
-    //   schema: "${schemaPath}",
-    //   files: ["${testDir}/non-existent-*.env"]
-    // };
-    // `;
-    //       fs.writeFileSync(configPath, configContent);
+      const configContent = `
+module.exports = {
+  schema: "${schemaPath}",
+  files: ["${testDir}/non-existent-*.env"]
+};
+`;
+      fs.writeFileSync(configPath, configContent);
 
-    //       const schemaContent = `
-    // type Env = {
-    //   API_KEY: string;
-    // };
-    // `;
-    //       fs.writeFileSync(schemaPath, schemaContent);
+      const schemaContent = `
+type Env = {
+  API_KEY: string;
+};
+`;
+      fs.writeFileSync(schemaPath, schemaContent);
 
-    //       await checkCommand({ config: configPath });
+      await checkCommand({ config: configPath });
 
-    //       expect(mockExit).not.toHaveBeenCalled();
-    //     });
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Throw an error when no files match the specified glob patterns instead of silently returning
- Provide descriptive error message listing the patterns that didn't match any files
- Add test case to verify the new error handling behavior

## Test plan
- [x] Existing tests continue to pass
- [x] New test case verifies error is thrown when no files match patterns
- [x] Type checking and linting passes

This resolves the TODO comment in the codebase and provides better user feedback when configuration patterns don't match any files.

🤖 Generated with [Claude Code](https://claude.ai/code)